### PR TITLE
FIX: Index TTS failing on SRT mode with timingmode=smart_natural

### DIFF
--- a/nodes/index_tts/index_tts_srt_processor.py
+++ b/nodes/index_tts/index_tts_srt_processor.py
@@ -324,7 +324,7 @@ class IndexTTSSRTProcessor:
             final_audio = assembler.assemble_smart_natural(
                 audio_segments, processed_segments, smart_adjustments, subtitles, torch.device('cpu')
             )
-            return final_audio, smart_adjustments  # Return the detailed smart adjustments
+            return final_audio, smart_adjustments, None  # Return the detailed smart adjustments
 
     def _generate_timing_report(self, subtitles: List, adjustments: List[Dict], timing_mode: str,
                                has_original_overlaps: bool = False, mode_switched: bool = False,


### PR DESCRIPTION
IndexTTS fails with the following error when timing mode is set to smart_natural

```
❌ TTS SRT generation failed: not enough values to unpack (expected 3, got 2)
Traceback (most recent call last):
  File "......../ComfyUI/custom_nodes/TTS-Audio-Suite/nodes/unified/tts_srt_node.py", line 796, in generate_srt_speech
    result = engine_instance.processor.process_srt_content(
        srt_content=srt_content,
    ...<3 lines>...
        timing_params=timing_params
    )
  File "......../ComfyUI/custom_nodes/TTS-Audio-Suite/nodes/index_tts/index_tts_srt_processor.py", line 150, in process_srt_content
    final_audio, final_adjustments, stretch_method = self._assemble_final_audio(
    
```

This fix ensures that the function contract is upheld for smart_natural as well.