### PR TITLE
Fix Qwen3-ASR check_model_inputs decorator usage

### DIFF
--- a/engines/qwen3_asr/impl/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
+++ b/engines/qwen3_asr/impl/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
@@ -983,8 +983,8 @@ class Qwen3ASRThinkerTextModel(Qwen3ASRPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    # PATCH (TTS Audio Suite): transformers compatibility - older versions require decorator without call
-    @check_model_inputs
+    # PATCH (TTS Audio Suite): transformers compatibility - check_model_inputs is a decorator factory in modern transformers
+    @check_model_inputs()
     @auto_docstring
     def forward(
         self,


### PR DESCRIPTION
This fixes a crash in the bundled Qwen3-ASR transformers backend when used with newer HuggingFace Transformers.

## Problem
`Qwen3ASRThinkerTextModel.forward()` is decorated with `@check_model_inputs`.
In modern `transformers` this symbol is a *decorator factory* (`check_model_inputs(...) -> wrapped_fn`), so it must be called as `@check_model_inputs()`.
When used as a plain decorator, `forward` becomes `wrapped_fn` and fails at runtime with unexpected kwargs.

### Runtime error
```
TypeError: check_model_inputs.<locals>.wrapped_fn() got an unexpected keyword argument 'attention_mask'
```

## Repro environment
- Python 3.12
- transformers 4.57.3
- accelerate 1.12.0

## Fix
Switch to `@check_model_inputs()`.

This is a minimal patch (no functional changes besides restoring compatibility).