### PR TITLE
Add compatibility fallback for model_mmap_residency

### DIFF
--- a/utils/models/comfyui_model_wrapper/base_wrapper.py
+++ b/utils/models/comfyui_model_wrapper/base_wrapper.py
@@ -175,7 +175,12 @@ class ComfyUIModelWrapper:
         Some interface implementations have been added, but the specific implementation details are not yet available.
         The main purpose is to ensure that the module can function properly first.
         """
-        return (0, 0)
+
+        try:
+            return (0, self.model_size())
+        except Exception:
+            return (0, 0)
+        
     
     def model_unload(self, memory_to_free: Optional[int] = None, unpatch_weights: bool = True) -> bool:
         """


### PR DESCRIPTION
Recent ComfyUI versions call `model_mmap_residency()` during memory management.

Some wrapped models do not implement this interface yet, which causes an
`AttributeError` and crashes execution.

This patch adds a minimal fallback implementation:

```python
def model_mmap_residency(self, free=False):
    try:
        return (0, self.model_size())
    except Exception:
        return (0, 0)
```

This is intended as a compatibility shim so existing models can continue to run
until proper mmap residency reporting is implemented.

This does not implement true mmap residency tracking; it only prevents hard crashes on newer ComfyUI versions.


reference:

ComfyUI，model_management.py

```python
for x in can_unload_sorted:
        i = x[-1]
        ram_to_free = ram_required - psutil.virtual_memory().available
        if ram_to_free <= 0 and i not in unloaded_model:
            continue
        resident_memory, _ = current_loaded_models[i].model_mmap_residency(free=True)
        if resident_memory > 0:
            logging.debug(f"RAM Unloading {current_loaded_models[i].model.model.__class__.__name__}")
```

```python
    for loaded_model in models_to_load:
        device = loaded_model.device
        total_memory_required[device] = total_memory_required.get(device, 0) + loaded_model.model_memory_required(device)
        resident_memory, model_memory = loaded_model.model_mmap_residency()
        pinned_memory = loaded_model.model.pinned_memory_size()
        #FIXME: This can over-free the pins as it budgets to pin the entire model. We should
        #make this JIT to keep as much pinned as possible.
        pins_required = model_memory - pinned_memory
        ram_required = model_memory - resident_memory
        total_pins_required[device] = total_pins_required.get(device, 0) + pins_required
        total_ram_required[device] = total_ram_required.get(device, 0) + ram_required
```