### PR TITLE
feat: add MiniMax Cloud TTS as 13th engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Subtitle workflows are still a core focus: the suite can transcribe to SRT, rebu
 
 <!-- ENGINE_COMPARISON_START -->
 
-## Quick Engine Comparison — 12 Engines
+## Quick Engine Comparison — 13 Engines
 
 | Engine | Languages | Size | Key Features |
 |--------|-----------|------|--------------|
@@ -38,6 +38,7 @@ Subtitle workflows are still a core focus: the suite can transcribe to SRT, rebu
 | **Granite ASR** | 🇺🇸​🇩🇪​🇪🇸​🇫🇷​🇯🇵​🇵🇹 | ~4.6GB | ASR (Automatic Speech Recognition), Custom timestamps/SRT via reused Qwen forced aligner |
 | **Step Audio EditX** | 🇺🇸​🇨🇳​🇯🇵​🇰🇷 | ~7GB | Second Pass Speech Editing Node: 14 emotions, 32 speaking styles |
 | **Echo-TTS** | 🇺🇸 | ~5.3GB + ~1.8GB | Diffusion-based (~30s best), Force Speaker KV (speaker drift control) |
+| **MiniMax Cloud TTS** | 🌐 Multilingual | Cloud API | No GPU needed, 12 built-in voices, HD & Turbo models |
 | **RVC** | 🌐 Any | 100-300MB | Real-time VC, Pitch shift (±14) |
 
 📊 **[Full comparison tables →](docs/ENGINE_COMPARISON.md)** | **[Language matrix →](docs/LANGUAGE_SUPPORT.md)** | **[Feature matrix →](docs/FEATURE_COMPARISON.md)** | **[Model download sources →](docs/MODEL_DOWNLOAD_SOURCES.md)** | **[Model folder layouts →](docs/MODEL_LAYOUTS.md)**
@@ -186,7 +187,7 @@ Switching [seed:24]   Inline Edit tags    TTS + VC             │
 
 ## Features
 
-- 🎤 **Multi-Engine TTS** - ChatterBox TTS, **Chatterbox Multilingual TTS**, F5-TTS, Higgs Audio 2, VibeVoice, **IndexTTS-2**, **CosyVoice3**, **Qwen3-TTS**, and **Echo-TTS** with voice cloning, reference audio synthesis, and production-grade quality
+- 🎤 **Multi-Engine TTS** - ChatterBox TTS, **Chatterbox Multilingual TTS**, F5-TTS, Higgs Audio 2, VibeVoice, **IndexTTS-2**, **CosyVoice3**, **Qwen3-TTS**, **Echo-TTS**, and **MiniMax Cloud TTS** with voice cloning, reference audio synthesis, and production-grade quality
 - ✏️ **ASR Transcription** - Unified ✏️ ASR Transcribe node with **Qwen3-ASR** and **Granite ASR**, plus optional custom timestamps/SRT for Granite via the reused Qwen forced aligner
 - 📺 **Text to SRT Builder** - Core modular subtitle pipeline with `📺 Text to SRT Builder` and `🔧 SRT Advanced Options`: rebuild SRT from edited transcripts, estimate timings from plain text using subtitle heuristics, and preserve project control tags for TTS-safe subtitle output
 - 🎨 **Audio Post-Processing** - **Step Audio EditX** LLM-based audio editing with paralinguistic effects (laughter, breathing, sigh), emotion control (14 emotions), speaking styles (32 styles), speed adjustment, and voice restoration → **[📖 Inline Edit Tags Guide](docs/INLINE_EDIT_TAGS_USER_GUIDE.md)**
@@ -856,6 +857,41 @@ Use the new [Unified ✏️ ASR Transcribe + SRT Builder](example_workflows/Unif
 3. First run auto-downloads the model (~7.1GB total) into `ComfyUI/models/TTS/echo-tts-base/`
 
 📖 **See [Model folder layouts](docs/MODEL_LAYOUTS.md#echo-tts) for detailed setup paths**
+
+</details>
+
+<details>
+<summary><h3>☁️ MiniMax Cloud TTS</h3></summary>
+
+Cloud-based text-to-speech via the MiniMax T2A v2 API — no GPU or local models required.
+
+* **☁️ Cloud API** — No model downloads, no GPU needed. Audio generated via MiniMax servers
+* **🎙️ 12 Built-in Voices** — English and multilingual voices (Graceful Lady, Deep Voice Man, Cute Boy, etc.)
+* **🔊 Two Models** — `speech-2.8-hd` (high quality) and `speech-2.8-turbo` (low latency)
+* **⚡ Speed Control** — Adjustable speech speed from 0.5x to 2.0x
+* **🔑 API Key Required** — Set `MINIMAX_API_KEY` environment variable ([get one here](https://platform.minimaxi.com/))
+
+**Usage:**
+1. Set `MINIMAX_API_KEY` environment variable
+2. Add `⚙️ MiniMax Cloud TTS Engine` node
+3. Select voice and model
+4. Connect to `🎤 TTS Text` or `📺 TTS SRT`
+
+**Available Voices:**
+| Voice ID | Description |
+|----------|-------------|
+| English_Graceful_Lady | Graceful Lady (English) |
+| English_Insightful_Speaker | Insightful Speaker (English) |
+| English_radiant_girl | Radiant Girl (English) |
+| English_Persuasive_Man | Persuasive Man (English) |
+| English_Lucky_Robot | Lucky Robot (English) |
+| Wise_Woman | Wise Woman |
+| cute_boy | Cute Boy |
+| lovely_girl | Lovely Girl |
+| Friendly_Person | Friendly Person |
+| Inspirational_girl | Inspirational Girl |
+| Deep_Voice_Man | Deep Voice Man |
+| sweet_girl | Sweet Girl |
 
 </details>
 

--- a/docs/Dev reports/tts_audio_suite_engines.yaml
+++ b/docs/Dev reports/tts_audio_suite_engines.yaml
@@ -1380,3 +1380,11 @@ model_layouts_markdown: |
 
   - Both components are required and auto-downloaded on first use.
   - License: CC-BY-NC-SA (non-commercial).
+
+  ## MiniMax Cloud TTS
+
+  No local model downloads required — audio is generated via the MiniMax T2A v2 cloud API.
+
+  Requirements:
+  - A valid `MINIMAX_API_KEY` environment variable (get one at https://platform.minimaxi.com/)
+  - Internet connectivity for API calls

--- a/engines/adapters/__init__.py
+++ b/engines/adapters/__init__.py
@@ -40,8 +40,18 @@ except ImportError as e:
         def __init__(self, *args, **kwargs):
             raise ImportError(f"Echo-TTS adapter not available: {e}")
 
+try:
+    from .minimax_tts_adapter import MiniMaxTTSAdapter
+    MINIMAX_TTS_ADAPTER_AVAILABLE = True
+except ImportError as e:
+    MINIMAX_TTS_ADAPTER_AVAILABLE = False
+    class MiniMaxTTSAdapter:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(f"MiniMax TTS adapter not available: {e}")
+
 __all__ = [
     'ChatterBoxEngineAdapter', 'F5TTSEngineAdapter', 'CosyVoiceAdapter', 'EchoTTSEngineAdapter',
+    'MiniMaxTTSAdapter',
     'CHATTERBOX_ADAPTER_AVAILABLE', 'F5TTS_ADAPTER_AVAILABLE', 'COSYVOICE_ADAPTER_AVAILABLE',
-    'ECHO_TTS_ADAPTER_AVAILABLE'
+    'ECHO_TTS_ADAPTER_AVAILABLE', 'MINIMAX_TTS_ADAPTER_AVAILABLE'
 ]

--- a/engines/adapters/minimax_tts_adapter.py
+++ b/engines/adapters/minimax_tts_adapter.py
@@ -1,0 +1,259 @@
+"""
+MiniMax Cloud TTS Engine Adapter
+
+Provides cloud-based text-to-speech via the MiniMax T2A v2 API.
+Unlike local TTS engines, this adapter requires a MINIMAX_API_KEY
+environment variable and makes HTTP requests to the MiniMax API.
+
+Supported models: speech-2.8-hd, speech-2.8-turbo
+Supported voices: 12 built-in English/multilingual voices
+"""
+
+import io
+import os
+import struct
+import torch
+from typing import Dict, Any, Optional, Tuple
+
+from utils.audio.cache import get_audio_cache
+from utils.text.chunking import ImprovedChatterBoxChunker
+from utils.audio.chunk_timing import ChunkTimingHelper
+
+
+# Verified voice IDs grouped by category
+MINIMAX_VOICES = {
+    "English_Graceful_Lady": "Graceful Lady (English)",
+    "English_Insightful_Speaker": "Insightful Speaker (English)",
+    "English_radiant_girl": "Radiant Girl (English)",
+    "English_Persuasive_Man": "Persuasive Man (English)",
+    "English_Lucky_Robot": "Lucky Robot (English)",
+    "Wise_Woman": "Wise Woman",
+    "cute_boy": "Cute Boy",
+    "lovely_girl": "Lovely Girl",
+    "Friendly_Person": "Friendly Person",
+    "Inspirational_girl": "Inspirational Girl",
+    "Deep_Voice_Man": "Deep Voice Man",
+    "sweet_girl": "Sweet Girl",
+}
+
+MINIMAX_VOICE_IDS = list(MINIMAX_VOICES.keys())
+
+MINIMAX_MODELS = ["speech-2.8-hd", "speech-2.8-turbo"]
+
+# MiniMax TTS outputs MP3 at 32000 Hz by default
+MINIMAX_TTS_SAMPLE_RATE = 32000
+
+
+class MiniMaxTTSAdapter:
+    """Adapter for MiniMax Cloud TTS API (T2A v2)."""
+
+    SAMPLE_RATE = MINIMAX_TTS_SAMPLE_RATE
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config.copy() if config else {}
+        self.audio_cache = get_audio_cache()
+
+    def update_config(self, new_config: Dict[str, Any]):
+        """Update adapter configuration."""
+        self.config = new_config.copy() if new_config else {}
+
+    def _get_api_key(self) -> str:
+        """Get MiniMax API key from config or environment."""
+        api_key = self.config.get("api_key") or os.environ.get("MINIMAX_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "MiniMax API key not found. Set the MINIMAX_API_KEY environment variable "
+                "or provide it in the engine configuration."
+            )
+        return api_key
+
+    def _call_tts_api(self, text: str, voice_id: str, model: str, speed: float) -> bytes:
+        """
+        Call MiniMax T2A v2 API and return raw audio bytes (MP3).
+
+        Args:
+            text: Text to synthesize
+            voice_id: MiniMax voice ID
+            model: Model name (speech-2.8-hd or speech-2.8-turbo)
+            speed: Speech speed multiplier (0.5-2.0)
+
+        Returns:
+            Raw MP3 audio bytes
+        """
+        import urllib.request
+        import json
+
+        api_key = self._get_api_key()
+        url = "https://api.minimax.io/v1/t2a_v2"
+
+        payload = {
+            "model": model,
+            "text": text,
+            "voice_setting": {
+                "voice_id": voice_id,
+                "speed": max(0.5, min(2.0, speed)),
+            },
+            "audio_setting": {
+                "format": "mp3",
+            },
+        }
+
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                body = resp.read()
+        except Exception as e:
+            raise RuntimeError(f"MiniMax TTS API request failed: {e}")
+
+        result = json.loads(body)
+
+        # Check for API errors
+        if result.get("base_resp", {}).get("status_code", 0) != 0:
+            status_msg = result.get("base_resp", {}).get("status_msg", "Unknown error")
+            raise RuntimeError(f"MiniMax TTS API error: {status_msg}")
+
+        # Extract hex-encoded audio from response
+        audio_hex = result.get("data", {}).get("audio", "")
+        if not audio_hex:
+            raise RuntimeError("MiniMax TTS API returned empty audio data")
+
+        return bytes.fromhex(audio_hex)
+
+    @staticmethod
+    def _decode_mp3_to_tensor(mp3_bytes: bytes) -> Tuple[torch.Tensor, int]:
+        """
+        Decode MP3 bytes to a torch tensor using torchaudio.
+
+        Returns:
+            Tuple of (audio_tensor [1D float32], sample_rate)
+        """
+        import torchaudio
+
+        # Write MP3 to a temporary buffer and decode
+        buffer = io.BytesIO(mp3_bytes)
+        waveform, sample_rate = torchaudio.load(buffer, format="mp3")
+
+        # Convert to mono if needed
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+
+        # Flatten to 1D
+        audio = waveform.squeeze(0)
+
+        # Normalize to [-1, 1]
+        max_val = audio.abs().max()
+        if max_val > 0 and max_val > 1.0:
+            audio = audio / max_val
+
+        return audio, sample_rate
+
+    def generate_single(
+        self, text: str, enable_audio_cache: bool = True, **kwargs
+    ) -> Tuple[torch.Tensor, int]:
+        """
+        Generate audio for a single text segment.
+
+        Args:
+            text: Text to synthesize
+            enable_audio_cache: Whether to use caching
+            **kwargs: Additional parameters (voice_id, model, speed)
+
+        Returns:
+            Tuple of (audio_tensor [1D float32], sample_rate)
+        """
+        voice_id = kwargs.get("voice_id") or self.config.get("voice_id", "English_Graceful_Lady")
+        model = kwargs.get("model") or self.config.get("model", "speech-2.8-hd")
+        speed = float(kwargs.get("speed") or self.config.get("speed", 1.0))
+
+        # Check cache
+        cache_key = None
+        if enable_audio_cache:
+            cache_key = self.audio_cache.generate_cache_key(
+                "minimax_tts",
+                text=text,
+                voice_id=voice_id,
+                model=model,
+                speed=speed,
+            )
+            cached_audio = self.audio_cache.get_cached_audio(cache_key)
+            if cached_audio:
+                print(f"\U0001f4be Using cached MiniMax TTS audio: '{text[:30]}...'")
+                return cached_audio[0], self.SAMPLE_RATE
+
+        # Call API
+        mp3_bytes = self._call_tts_api(text, voice_id, model, speed)
+
+        # Decode
+        audio_tensor, sample_rate = self._decode_mp3_to_tensor(mp3_bytes)
+
+        # Cache
+        if enable_audio_cache and cache_key:
+            duration = audio_tensor.shape[-1] / float(sample_rate)
+            self.audio_cache.cache_audio(cache_key, audio_tensor, duration)
+
+        self.SAMPLE_RATE = sample_rate
+        return audio_tensor, sample_rate
+
+    def process_text(
+        self,
+        text: str,
+        enable_chunking: bool = True,
+        max_chars_per_chunk: int = 400,
+        chunk_combination_method: str = "auto",
+        silence_between_chunks_ms: int = 100,
+        enable_audio_cache: bool = True,
+        return_info: bool = False,
+    ):
+        """
+        Process text with optional chunking and combine audio segments.
+
+        Args:
+            text: Text to synthesize
+            enable_chunking: Whether to split text into chunks
+            max_chars_per_chunk: Maximum characters per chunk
+            chunk_combination_method: How to combine chunks
+            silence_between_chunks_ms: Silence padding between chunks
+            enable_audio_cache: Whether to cache audio
+            return_info: Whether to return chunk timing info
+
+        Returns:
+            audio_tensor or (audio_tensor, chunk_info) if return_info=True
+        """
+        if enable_chunking:
+            max_chars = ImprovedChatterBoxChunker.validate_chunking_params(max_chars_per_chunk)
+            text_chunks = ImprovedChatterBoxChunker.split_into_chunks(text, max_chars=max_chars)
+        else:
+            text_chunks = [text]
+
+        audio_segments = []
+        sample_rate = self.SAMPLE_RATE
+
+        for chunk in text_chunks:
+            audio_tensor, sr = self.generate_single(chunk, enable_audio_cache=enable_audio_cache)
+            sample_rate = sr
+            audio_segments.append(audio_tensor)
+
+        combined_audio, chunk_info = ChunkTimingHelper.combine_audio_with_timing(
+            audio_segments=audio_segments,
+            combination_method=chunk_combination_method,
+            silence_ms=silence_between_chunks_ms,
+            crossfade_duration=0.1,
+            sample_rate=sample_rate,
+            text_length=len(text),
+            original_text=text,
+            text_chunks=text_chunks,
+        )
+
+        if return_info:
+            return combined_audio, chunk_info
+        return combined_audio

--- a/nodes.py
+++ b/nodes.py
@@ -169,6 +169,14 @@ except Exception as e:
     print(f"❌ CosyVoice3 Engine failed: {e}")
     COSYVOICE_ENGINE_AVAILABLE = False
 
+try:
+    minimax_tts_engine_module = load_node_module("minimax_tts_engine_node", "engines/minimax_tts_engine_node.py")
+    MiniMaxTTSEngineNode = minimax_tts_engine_module.MiniMaxTTSEngineNode
+    MINIMAX_TTS_ENGINE_AVAILABLE = True
+except Exception as e:
+    print(f"❌ MiniMax Cloud TTS Engine failed: {e}")
+    MINIMAX_TTS_ENGINE_AVAILABLE = False
+
 # IndexTTS-2 Emotion Options Node
 try:
     index_tts_emotion_options_module = load_node_module("index_tts_emotion_options_node", "engines/index_tts_emotion_options_node.py")
@@ -532,6 +540,10 @@ if INDEX_TTS_ENGINE_AVAILABLE:
 if COSYVOICE_ENGINE_AVAILABLE:
     NODE_CLASS_MAPPINGS["CosyVoiceEngineNode"] = CosyVoiceEngineNode
     NODE_DISPLAY_NAME_MAPPINGS["CosyVoiceEngineNode"] = "⚙️ CosyVoice3 Engine"
+
+if MINIMAX_TTS_ENGINE_AVAILABLE:
+    NODE_CLASS_MAPPINGS["MiniMaxTTSEngineNode"] = MiniMaxTTSEngineNode
+    NODE_DISPLAY_NAME_MAPPINGS["MiniMaxTTSEngineNode"] = "⚙️ MiniMax Cloud TTS Engine"
 
 if INDEX_TTS_EMOTION_OPTIONS_AVAILABLE:
     NODE_CLASS_MAPPINGS["IndexTTSEmotionOptionsNode"] = IndexTTSEmotionOptionsNode

--- a/nodes/engines/minimax_tts_engine_node.py
+++ b/nodes/engines/minimax_tts_engine_node.py
@@ -1,0 +1,152 @@
+"""
+MiniMax Cloud TTS Engine Configuration Node
+
+Provides MiniMax Cloud TTS configuration for TTS Audio Suite.
+Requires a MINIMAX_API_KEY environment variable.
+
+MiniMax T2A v2 API: https://platform.minimaxi.com/document/T2A%20V2
+Models: speech-2.8-hd (high quality), speech-2.8-turbo (low latency)
+"""
+
+import os
+import sys
+import importlib.util
+from typing import Dict, Any
+
+# Add project root directory to path for imports
+current_dir = os.path.dirname(__file__)
+nodes_dir = os.path.dirname(current_dir)  # nodes/
+project_root = os.path.dirname(nodes_dir)  # project root
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Load base_node module directly
+base_node_path = os.path.join(nodes_dir, "base", "base_node.py")
+base_spec = importlib.util.spec_from_file_location("base_node_module", base_node_path)
+base_module = importlib.util.module_from_spec(base_spec)
+sys.modules["base_node_module"] = base_module
+base_spec.loader.exec_module(base_module)
+
+# Import the base class
+BaseTTSNode = base_module.BaseTTSNode
+
+
+class MiniMaxTTSEngineNode(BaseTTSNode):
+    """
+    MiniMax Cloud TTS engine configuration node.
+
+    Uses the MiniMax T2A v2 API for cloud-based text-to-speech.
+    Requires MINIMAX_API_KEY environment variable.
+    """
+
+    @classmethod
+    def NAME(cls):
+        return "MiniMax Cloud TTS Engine"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        from engines.adapters.minimax_tts_adapter import MINIMAX_VOICE_IDS, MINIMAX_MODELS
+
+        return {
+            "required": {
+                "model": (MINIMAX_MODELS, {
+                    "default": "speech-2.8-hd",
+                    "tooltip": (
+                        "MiniMax TTS model:\n"
+                        "- speech-2.8-hd: High-definition quality, best for final output\n"
+                        "- speech-2.8-turbo: Lower latency, good for previews"
+                    ),
+                }),
+                "voice_id": (MINIMAX_VOICE_IDS, {
+                    "default": "English_Graceful_Lady",
+                    "tooltip": (
+                        "Built-in voice to use for speech synthesis.\n"
+                        "12 voices available across English and multilingual styles."
+                    ),
+                }),
+                "speed": ("FLOAT", {
+                    "default": 1.0,
+                    "min": 0.5,
+                    "max": 2.0,
+                    "step": 0.05,
+                    "tooltip": "Speech speed multiplier. 1.0 = normal, <1.0 = slower, >1.0 = faster.",
+                }),
+            },
+            "optional": {
+                "api_key": ("STRING", {
+                    "default": "",
+                    "tooltip": (
+                        "MiniMax API key. If empty, reads from MINIMAX_API_KEY environment variable.\n"
+                        "Get your API key at https://platform.minimaxi.com/"
+                    ),
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("TTS_ENGINE",)
+    RETURN_NAMES = ("TTS_engine",)
+    FUNCTION = "create_engine_adapter"
+    CATEGORY = "TTS Audio Suite/Engines"
+
+    def create_engine_adapter(self, model: str, voice_id: str, speed: float,
+                              api_key: str = ""):
+        """Create MiniMax Cloud TTS engine configuration."""
+        try:
+            # Verify adapter is importable
+            from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+            _ = MiniMaxTTSAdapter  # silence unused
+
+            config = {
+                "engine_type": "minimax_tts",
+                "model": model,
+                "voice_id": voice_id,
+                "speed": float(speed),
+            }
+
+            # Only store API key in config if explicitly provided
+            if api_key:
+                config["api_key"] = api_key
+
+            # Check API key availability
+            resolved_key = api_key or os.environ.get("MINIMAX_API_KEY", "")
+            key_source = "config" if api_key else ("env" if resolved_key else "missing")
+
+            print(f"MiniMax Cloud TTS Engine: model={model}, voice={voice_id}, speed={speed:.2f}")
+            if key_source == "missing":
+                print("   \u26a0\ufe0f WARNING: No API key found. Set MINIMAX_API_KEY environment variable.")
+            else:
+                print(f"   API key source: {key_source}")
+
+            engine_data = {
+                "engine_type": "minimax_tts",
+                "config": config,
+                "adapter_class": "MiniMaxTTSAdapter",
+            }
+
+            return (engine_data,)
+
+        except Exception as e:
+            print(f"ERROR: MiniMax Cloud TTS Engine error: {e}")
+            import traceback
+            traceback.print_exc()
+
+            error_config = {
+                "engine_type": "minimax_tts",
+                "config": {
+                    "model": model,
+                    "voice_id": voice_id,
+                    "error": str(e),
+                },
+                "adapter_class": "MiniMaxTTSAdapter",
+            }
+            return (error_config,)
+
+
+# Register the node class
+NODE_CLASS_MAPPINGS = {
+    "MiniMaxTTSEngineNode": MiniMaxTTSEngineNode,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "MiniMaxTTSEngineNode": "MiniMax Cloud TTS Engine",
+}

--- a/nodes/unified/tts_srt_node.py
+++ b/nodes/unified/tts_srt_node.py
@@ -668,9 +668,29 @@ Hello! This is unified SRT TTS with character switching.
                 }
                 return engine_instance
 
+            elif engine_type == "minimax_tts":
+                from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+                class MiniMaxTTSSRTWrapper:
+                    def __init__(self, cfg):
+                        self.config = cfg.copy()
+                        self.adapter = MiniMaxTTSAdapter(self.config)
+
+                    def update_config(self, new_config):
+                        self.config = new_config.copy()
+                        self.adapter.update_config(new_config)
+
+                engine_instance = MiniMaxTTSSRTWrapper(config)
+                import time
+                self._cached_engine_instances[cache_key] = {
+                    'instance': engine_instance,
+                    'timestamp': time.time()
+                }
+                return engine_instance
+
             else:
                 raise ValueError(f"Unknown engine type: {engine_type}")
-                
+
         except Exception as e:
             print(f"❌ Failed to create engine SRT node instance: {e}")
             return None
@@ -1132,10 +1152,105 @@ Hello! This is unified SRT TTS with character switching.
                     timing_params=timing_params
                 )
 
+            elif engine_type == "minimax_tts":
+                # MiniMax Cloud TTS - SRT processing with timing
+                from utils.system.import_manager import import_manager
+                from utils.timing.assembly import AudioAssemblyEngine
+                from utils.timing.engine import TimingEngine
+                from utils.timing.overlap_detection import SRTOverlapHandler
+                from utils.audio.processing import AudioProcessingUtils
+
+                success, modules, _ = import_manager.import_srt_modules()
+                if not success:
+                    raise RuntimeError("SRT modules are not available")
+
+                SRTParser = modules.get("SRTParser")
+                if SRTParser is None:
+                    raise RuntimeError("SRT parser not available")
+
+                srt_parser = SRTParser()
+                subtitles = srt_parser.parse_srt_content(srt_content, allow_overlaps=True)
+                has_overlaps = SRTOverlapHandler.detect_overlaps(subtitles)
+                current_timing_mode, mode_switched = SRTOverlapHandler.handle_smart_natural_fallback(
+                    timing_mode, has_overlaps, "MiniMax Cloud TTS SRT"
+                )
+
+                adapter = engine_instance.adapter
+                sample_rate = adapter.SAMPLE_RATE
+
+                audio_segments = []
+                for subtitle in subtitles:
+                    audio_tensor_seg, sr = adapter.generate_single(
+                        subtitle.text, enable_audio_cache=True
+                    )
+                    sample_rate = sr
+                    audio_segments.append(audio_tensor_seg.cpu())
+
+                adjustments = None
+                processed_segments = None
+
+                timing_params_dict = {
+                    'fade_for_StretchToFit': fade_for_StretchToFit,
+                    'max_stretch_ratio': max_stretch_ratio,
+                    'min_stretch_ratio': min_stretch_ratio,
+                    'timing_tolerance': timing_tolerance
+                }
+                fade_duration = float(timing_params_dict.get("fade_for_StretchToFit", 0.01))
+
+                if current_timing_mode == "concatenate":
+                    timing_engine = TimingEngine(sample_rate)
+                    adjustments = timing_engine.calculate_concatenation_adjustments(audio_segments, subtitles)
+                elif current_timing_mode == "smart_natural":
+                    timing_engine = TimingEngine(sample_rate)
+                    tolerance = float(timing_params_dict.get("timing_tolerance", 2.0))
+                    max_sr = float(timing_params_dict.get("max_stretch_ratio", 1.0))
+                    min_sr = float(timing_params_dict.get("min_stretch_ratio", 0.5))
+                    adjustments, processed_segments = timing_engine.calculate_smart_timing_adjustments(
+                        audio_segments, subtitles, tolerance, max_sr, min_sr, torch.device("cpu"),
+                    )
+
+                assembler = AudioAssemblyEngine(sample_rate=sample_rate)
+                final_audio = assembler.assemble_by_timing_mode(
+                    audio_segments=audio_segments,
+                    subtitles=subtitles,
+                    timing_mode=current_timing_mode,
+                    device="cpu",
+                    adjustments=adjustments,
+                    processed_segments=processed_segments,
+                    fade_duration=fade_duration,
+                )
+
+                if final_audio.dim() == 1:
+                    final_audio = final_audio.unsqueeze(0).unsqueeze(0)
+                elif final_audio.dim() == 2:
+                    final_audio = final_audio.unsqueeze(0)
+
+                audio_output = {"waveform": final_audio, "sample_rate": sample_rate}
+
+                timing_info = srt_parser.get_timing_info(subtitles)
+                mode_info = current_timing_mode
+                if mode_switched:
+                    mode_info = f"{current_timing_mode} (switched from {timing_mode} due to overlaps)"
+
+                timing_report = (
+                    f"MiniMax Cloud TTS SRT timing\n"
+                    f"Subtitles: {timing_info.get('subtitle_count', 0)}\n"
+                    f"Total duration: {timing_info.get('total_duration', 0):.2f}s\n"
+                    f"Mode: {mode_info}"
+                )
+
+                total_duration = final_audio.shape[-1] / float(sample_rate)
+                voice_id = config.get("voice_id", "English_Graceful_Lady")
+                model_name = config.get("model", "speech-2.8-hd")
+                generation_info = (
+                    f"Generated {total_duration:.1f}s MiniMax Cloud TTS SRT audio "
+                    f"(model: {model_name}, voice: {voice_id}) using {mode_info} mode"
+                )
+
+                result = (audio_output, generation_info, timing_report, srt_content)
+
             else:
                 raise ValueError(f"Unknown engine type: {engine_type}")
-            
-            # The original SRT nodes return (audio, generation_info, timing_report, adjusted_srt)
             audio_output, generation_info, timing_report, adjusted_srt = result
             
             # Ensure audio tensor is moved to CPU and has correct dtype

--- a/nodes/unified/tts_text_node.py
+++ b/nodes/unified/tts_text_node.py
@@ -606,9 +606,32 @@ Back to the main narrator voice for the conclusion.""",
                 }
                 return engine_instance
 
+            elif engine_type == "minimax_tts":
+                from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+                class MiniMaxTTSWrapper:
+                    def __init__(self, cfg):
+                        self.config = cfg.copy()
+                        self.adapter = MiniMaxTTSAdapter(self.config)
+
+                    def update_config(self, new_config):
+                        self.config = new_config.copy()
+                        self.adapter.update_config(new_config)
+
+                engine_instance = MiniMaxTTSWrapper(config)
+
+                # Cache the instance with timestamp
+                import time
+                self._cached_engine_instances[cache_key] = {
+                    'instance': engine_instance,
+                    'timestamp': time.time()
+                }
+
+                return engine_instance
+
             else:
                 raise ValueError(f"Unknown engine type: {engine_type}")
-                
+
         except Exception as e:
             print(f"❌ Failed to create engine node instance: {e}")
             return None
@@ -1447,6 +1470,37 @@ Back to the main narrator voice for the conclusion.""",
                     character=char_display,
                     seed=seed
                 )
+
+            elif engine_type == "minimax_tts":
+                # MiniMax Cloud TTS - no reference audio needed (uses built-in voices)
+                import re
+                from utils.audio.chunk_timing import ChunkTimingHelper
+
+                audio_result, chunk_info = engine_instance.adapter.process_text(
+                    text=text,
+                    enable_chunking=enable_chunking,
+                    max_chars_per_chunk=max_chars_per_chunk,
+                    chunk_combination_method=chunk_combination_method,
+                    silence_between_chunks_ms=silence_between_chunks_ms,
+                    enable_audio_cache=enable_audio_cache,
+                    return_info=True,
+                )
+
+                sample_rate = engine_instance.adapter.SAMPLE_RATE
+                total_duration = audio_result.shape[-1] / float(sample_rate) if audio_result.numel() else 0.0
+                clean_text = re.sub(r'\[.*?\]', '', text)
+                text_length = len(clean_text)
+
+                voice_id = config.get("voice_id", "English_Graceful_Lady")
+                model_name = config.get("model", "speech-2.8-hd")
+                base_info = (
+                    f"Generated {total_duration:.1f}s audio from {text_length} characters "
+                    f"(MiniMax Cloud TTS, model: {model_name}, voice: {voice_id})"
+                )
+                generation_info = ChunkTimingHelper.enhance_generation_info(f"✅ {base_info}", chunk_info)
+
+                formatted_audio = AudioProcessingUtils.format_for_comfyui(audio_result, sample_rate)
+                result = (formatted_audio, generation_info)
 
             else:
                 raise ValueError(f"Unknown engine type: {engine_type}")

--- a/tests/integration/test_minimax_tts_integration.py
+++ b/tests/integration/test_minimax_tts_integration.py
@@ -1,0 +1,245 @@
+"""
+Integration tests for MiniMax Cloud TTS Engine
+
+Tests the full integration path: engine node -> adapter -> API (mocked).
+These tests verify the node registration, engine data format, and end-to-end
+processing without requiring a real API key or ComfyUI server.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+# Add custom node root to path BEFORE any project imports
+custom_node_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(custom_node_root))
+
+os.environ.setdefault("COMFYUI_TESTING", "1")
+
+# Mock torchaudio if not available (CI environments without GPU deps)
+if "torchaudio" not in sys.modules:
+    try:
+        import torchaudio  # noqa: F401
+    except ImportError:
+        sys.modules["torchaudio"] = MagicMock()
+        sys.modules["torchaudio.transforms"] = MagicMock()
+
+
+def _make_api_response(audio_hex: str = "aabb", status_code: int = 0,
+                       status_msg: str = "success") -> bytes:
+    """Build a fake MiniMax T2A v2 JSON response."""
+    return json.dumps({
+        "base_resp": {"status_code": status_code, "status_msg": status_msg},
+        "data": {"audio": audio_hex},
+    }).encode("utf-8")
+
+
+import importlib.util
+
+# Helper to load engine node module directly (avoids ComfyUI 'nodes' mock conflict)
+def _load_engine_node_module():
+    """Load MiniMaxTTSEngineNode via importlib to bypass 'nodes' mock."""
+    node_path = custom_node_root / "nodes" / "engines" / "minimax_tts_engine_node.py"
+    spec = importlib.util.spec_from_file_location("minimax_tts_engine_node", str(node_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.integration
+class TestMiniMaxTTSEngineNodeIntegration:
+    """Tests for the engine node creating correct engine_data."""
+
+    def test_engine_node_creates_valid_engine_data(self):
+        """Engine node should produce a valid TTS_ENGINE dict."""
+        mod = _load_engine_node_module()
+        MiniMaxTTSEngineNode = mod.MiniMaxTTSEngineNode
+
+        node = MiniMaxTTSEngineNode()
+        result = node.create_engine_adapter(
+            model="speech-2.8-hd",
+            voice_id="English_Graceful_Lady",
+            speed=1.0,
+            api_key="test-key",
+        )
+
+        engine_data = result[0]
+        assert engine_data["engine_type"] == "minimax_tts"
+        assert engine_data["adapter_class"] == "MiniMaxTTSAdapter"
+        assert engine_data["config"]["model"] == "speech-2.8-hd"
+        assert engine_data["config"]["voice_id"] == "English_Graceful_Lady"
+        assert engine_data["config"]["speed"] == 1.0
+        assert engine_data["config"]["api_key"] == "test-key"
+
+    def test_engine_node_no_api_key_in_config_when_empty(self):
+        """Engine node should not store empty API key in config."""
+        mod = _load_engine_node_module()
+        MiniMaxTTSEngineNode = mod.MiniMaxTTSEngineNode
+
+        node = MiniMaxTTSEngineNode()
+        result = node.create_engine_adapter(
+            model="speech-2.8-turbo",
+            voice_id="cute_boy",
+            speed=1.5,
+            api_key="",
+        )
+
+        engine_data = result[0]
+        assert "api_key" not in engine_data["config"]
+
+    def test_engine_node_return_type(self):
+        """Engine node should return a tuple with TTS_ENGINE."""
+        mod = _load_engine_node_module()
+        MiniMaxTTSEngineNode = mod.MiniMaxTTSEngineNode
+
+        node = MiniMaxTTSEngineNode()
+        result = node.create_engine_adapter(
+            model="speech-2.8-hd",
+            voice_id="Wise_Woman",
+            speed=0.8,
+        )
+
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+
+    def test_engine_node_class_metadata(self):
+        """Engine node should have correct ComfyUI metadata."""
+        mod = _load_engine_node_module()
+        MiniMaxTTSEngineNode = mod.MiniMaxTTSEngineNode
+
+        assert MiniMaxTTSEngineNode.RETURN_TYPES == ("TTS_ENGINE",)
+        assert MiniMaxTTSEngineNode.FUNCTION == "create_engine_adapter"
+        assert "Engines" in MiniMaxTTSEngineNode.CATEGORY
+
+    def test_engine_node_input_types(self):
+        """Engine node should declare correct input types."""
+        mod = _load_engine_node_module()
+        MiniMaxTTSEngineNode = mod.MiniMaxTTSEngineNode
+
+        input_types = MiniMaxTTSEngineNode.INPUT_TYPES()
+
+        assert "model" in input_types["required"]
+        assert "voice_id" in input_types["required"]
+        assert "speed" in input_types["required"]
+        assert "api_key" in input_types.get("optional", {})
+
+
+@pytest.mark.integration
+class TestMiniMaxTTSAdapterEndToEnd:
+    """End-to-end tests for adapter with mocked API."""
+
+    def test_full_generation_flow(self):
+        """Test the complete flow: config -> adapter -> generate_single."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "test-key",
+            "voice_id": "English_Graceful_Lady",
+            "model": "speech-2.8-hd",
+            "speed": 1.0,
+        })
+
+        fake_audio = torch.randn(32000)  # 1 second at 32kHz
+
+        with patch.object(adapter, "_call_tts_api", return_value=b"\x00" * 100):
+            with patch.object(adapter, "_decode_mp3_to_tensor",
+                              return_value=(fake_audio, 32000)):
+                audio, sr = adapter.generate_single(
+                    "Hello, this is a test.", enable_audio_cache=False
+                )
+
+        assert isinstance(audio, torch.Tensor)
+        assert audio.dim() == 1
+        assert sr == 32000
+        assert audio.shape[0] == 32000
+
+    def test_process_text_with_chunking(self):
+        """Test text processing with chunking enabled."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "test-key",
+            "voice_id": "cute_boy",
+            "model": "speech-2.8-turbo",
+        })
+
+        # Generate a long text that will be chunked
+        long_text = "This is a test sentence. " * 30  # ~750 chars
+
+        chunk_audio = torch.randn(16000)
+
+        with patch.object(adapter, "generate_single",
+                          return_value=(chunk_audio, 32000)):
+            result = adapter.process_text(
+                long_text,
+                enable_chunking=True,
+                max_chars_per_chunk=200,
+                enable_audio_cache=False,
+            )
+
+        assert isinstance(result, torch.Tensor)
+        # Result should be longer than a single chunk since text was chunked
+        assert result.numel() > 0
+
+    def test_adapter_caching(self):
+        """Test that identical requests use cache."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "test-key",
+            "voice_id": "cute_boy",
+            "model": "speech-2.8-hd",
+        })
+
+        fake_audio = torch.randn(16000)
+        call_count = 0
+
+        def counting_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return b"\x00" * 100
+
+        with patch.object(adapter, "_call_tts_api", side_effect=counting_call):
+            with patch.object(adapter, "_decode_mp3_to_tensor",
+                              return_value=(fake_audio, 32000)):
+                # First call - should hit API
+                adapter.generate_single("Cached test", enable_audio_cache=True)
+                first_count = call_count
+
+                # Second call with same text - should use cache
+                adapter.generate_single("Cached test", enable_audio_cache=True)
+                second_count = call_count
+
+        assert first_count == 1
+        assert second_count == 1  # No additional API call
+
+
+@pytest.mark.integration
+class TestMiniMaxTTSNodeRegistration:
+    """Tests for node registration in the engine system."""
+
+    def test_adapter_importable(self):
+        """MiniMax TTS adapter should be importable."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        assert MiniMaxTTSAdapter is not None
+
+    def test_adapter_available_flag(self):
+        """MiniMax TTS adapter availability flag should be set."""
+        from engines.adapters import MINIMAX_TTS_ADAPTER_AVAILABLE
+        assert MINIMAX_TTS_ADAPTER_AVAILABLE is True
+
+    def test_engine_node_mappings(self):
+        """Engine node should have correct NODE_CLASS_MAPPINGS."""
+        mod = _load_engine_node_module()
+        NODE_CLASS_MAPPINGS = mod.NODE_CLASS_MAPPINGS
+        NODE_DISPLAY_NAME_MAPPINGS = mod.NODE_DISPLAY_NAME_MAPPINGS
+
+        assert "MiniMaxTTSEngineNode" in NODE_CLASS_MAPPINGS
+        assert "MiniMaxTTSEngineNode" in NODE_DISPLAY_NAME_MAPPINGS
+        assert "MiniMax" in NODE_DISPLAY_NAME_MAPPINGS["MiniMaxTTSEngineNode"]

--- a/tests/unit/test_minimax_tts_adapter.py
+++ b/tests/unit/test_minimax_tts_adapter.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for MiniMax Cloud TTS Engine Adapter
+
+Tests engines/adapters/minimax_tts_adapter.py without requiring ComfyUI server
+or actual API calls.
+"""
+
+import json
+import os
+import sys
+import struct
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+import torch
+
+# Add custom node root to path BEFORE any project imports
+custom_node_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(custom_node_root))
+
+# Set up minimal environment to avoid ComfyUI imports
+os.environ.setdefault("COMFYUI_TESTING", "1")
+
+# Mock torchaudio if not available (CI environments without GPU deps)
+if "torchaudio" not in sys.modules:
+    try:
+        import torchaudio  # noqa: F401
+    except ImportError:
+        sys.modules["torchaudio"] = MagicMock()
+        sys.modules["torchaudio.transforms"] = MagicMock()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _make_api_response(audio_hex: str = "", status_code: int = 0,
+                       status_msg: str = "success") -> bytes:
+    """Build a fake MiniMax T2A v2 JSON response."""
+    return json.dumps({
+        "base_resp": {"status_code": status_code, "status_msg": status_msg},
+        "data": {"audio": audio_hex},
+    }).encode("utf-8")
+
+
+def _hex_for_silence_wav(num_samples: int = 1600, sample_rate: int = 32000) -> str:
+    """
+    Create a minimal WAV file in memory and return its hex representation.
+    This avoids needing actual MP3 encoding for unit tests.
+    """
+    # We'll use the torchaudio mock instead — tests that need real decoding
+    # will mock _decode_mp3_to_tensor directly.
+    return "00" * 100  # Placeholder hex
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.unit
+class TestMiniMaxTTSAdapterConfig:
+    """Tests for adapter configuration."""
+
+    def test_init_with_empty_config(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({})
+        assert adapter.config == {}
+
+    def test_init_preserves_config(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        cfg = {"model": "speech-2.8-turbo", "voice_id": "cute_boy"}
+        adapter = MiniMaxTTSAdapter(cfg)
+        assert adapter.config["model"] == "speech-2.8-turbo"
+        assert adapter.config["voice_id"] == "cute_boy"
+
+    def test_init_copies_config(self):
+        """Adapter should copy config to avoid external mutations."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        cfg = {"model": "speech-2.8-hd"}
+        adapter = MiniMaxTTSAdapter(cfg)
+        cfg["model"] = "changed"
+        assert adapter.config["model"] == "speech-2.8-hd"
+
+    def test_update_config(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({"model": "speech-2.8-hd"})
+        adapter.update_config({"model": "speech-2.8-turbo", "speed": 1.5})
+        assert adapter.config["model"] == "speech-2.8-turbo"
+        assert adapter.config["speed"] == 1.5
+
+    def test_update_config_copies(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({})
+        new_cfg = {"model": "speech-2.8-hd"}
+        adapter.update_config(new_cfg)
+        new_cfg["model"] = "mutated"
+        assert adapter.config["model"] == "speech-2.8-hd"
+
+
+@pytest.mark.unit
+class TestMiniMaxTTSAdapterAPIKey:
+    """Tests for API key resolution."""
+
+    def test_get_api_key_from_config(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key-123"})
+        assert adapter._get_api_key() == "test-key-123"
+
+    def test_get_api_key_from_env(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({})
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key-456"}):
+            assert adapter._get_api_key() == "env-key-456"
+
+    def test_get_api_key_config_priority(self):
+        """Config API key should take priority over env."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({"api_key": "config-key"})
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
+            assert adapter._get_api_key() == "config-key"
+
+    def test_get_api_key_missing_raises(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+        adapter = MiniMaxTTSAdapter({})
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove MINIMAX_API_KEY if present
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with pytest.raises(ValueError, match="API key not found"):
+                adapter._get_api_key()
+
+
+@pytest.mark.unit
+class TestMiniMaxTTSAdapterAPICall:
+    """Tests for API request building and response parsing."""
+
+    def test_call_tts_api_builds_correct_payload(self):
+        """Verify the API call sends the right JSON payload."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key"})
+
+        captured_request = {}
+
+        def mock_urlopen(req, timeout=None):
+            captured_request["url"] = req.full_url
+            captured_request["data"] = json.loads(req.data.decode("utf-8"))
+            captured_request["headers"] = dict(req.headers)
+
+            # Return valid response
+            resp = MagicMock()
+            resp.read.return_value = _make_api_response(audio_hex="aabbcc")
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            result = adapter._call_tts_api("Hello world", "cute_boy", "speech-2.8-hd", 1.2)
+
+        assert captured_request["url"] == "https://api.minimax.io/v1/t2a_v2"
+        payload = captured_request["data"]
+        assert payload["model"] == "speech-2.8-hd"
+        assert payload["text"] == "Hello world"
+        assert payload["voice_setting"]["voice_id"] == "cute_boy"
+        assert payload["voice_setting"]["speed"] == 1.2
+        assert payload["audio_setting"]["format"] == "mp3"
+        assert result == bytes.fromhex("aabbcc")
+
+    def test_call_tts_api_clamps_speed(self):
+        """Speed should be clamped to [0.5, 2.0]."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key"})
+        captured_payload = {}
+
+        def mock_urlopen(req, timeout=None):
+            captured_payload.update(json.loads(req.data.decode("utf-8")))
+            resp = MagicMock()
+            resp.read.return_value = _make_api_response(audio_hex="aa")
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            adapter._call_tts_api("test", "cute_boy", "speech-2.8-hd", 0.1)
+            assert captured_payload["voice_setting"]["speed"] == 0.5
+
+            adapter._call_tts_api("test", "cute_boy", "speech-2.8-hd", 5.0)
+            assert captured_payload["voice_setting"]["speed"] == 2.0
+
+    def test_call_tts_api_error_response(self):
+        """API error response should raise RuntimeError."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key"})
+
+        def mock_urlopen(req, timeout=None):
+            resp = MagicMock()
+            resp.read.return_value = _make_api_response(
+                status_code=1001, status_msg="Invalid API key"
+            )
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            with pytest.raises(RuntimeError, match="Invalid API key"):
+                adapter._call_tts_api("test", "cute_boy", "speech-2.8-hd", 1.0)
+
+    def test_call_tts_api_empty_audio(self):
+        """Empty audio hex should raise RuntimeError."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key"})
+
+        def mock_urlopen(req, timeout=None):
+            resp = MagicMock()
+            resp.read.return_value = _make_api_response(audio_hex="")
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            with pytest.raises(RuntimeError, match="empty audio"):
+                adapter._call_tts_api("test", "cute_boy", "speech-2.8-hd", 1.0)
+
+    def test_call_tts_api_network_error(self):
+        """Network errors should be wrapped in RuntimeError."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "test-key"})
+
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("timeout")):
+            with pytest.raises(RuntimeError, match="request failed"):
+                adapter._call_tts_api("test", "cute_boy", "speech-2.8-hd", 1.0)
+
+
+@pytest.mark.unit
+class TestMiniMaxTTSAdapterGenerate:
+    """Tests for generate_single method."""
+
+    def test_generate_single_returns_tensor(self):
+        """generate_single should return (tensor, sample_rate) tuple."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "test-key",
+            "voice_id": "cute_boy",
+            "model": "speech-2.8-hd",
+        })
+
+        fake_audio = torch.randn(16000)
+
+        with patch.object(adapter, "_call_tts_api", return_value=b"\x00" * 100):
+            with patch.object(adapter, "_decode_mp3_to_tensor",
+                              return_value=(fake_audio, 32000)):
+                audio, sr = adapter.generate_single("Hello", enable_audio_cache=False)
+
+        assert isinstance(audio, torch.Tensor)
+        assert audio.shape == fake_audio.shape
+        assert sr == 32000
+
+    def test_generate_single_uses_config_defaults(self):
+        """generate_single should use config values when kwargs not provided."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "k",
+            "voice_id": "Deep_Voice_Man",
+            "model": "speech-2.8-turbo",
+            "speed": 1.5,
+        })
+
+        captured_args = {}
+        original_call = adapter._call_tts_api
+
+        def capture_call(text, voice_id, model, speed):
+            captured_args.update({
+                "voice_id": voice_id,
+                "model": model,
+                "speed": speed,
+            })
+            return b"\x00" * 100
+
+        with patch.object(adapter, "_call_tts_api", side_effect=capture_call):
+            with patch.object(adapter, "_decode_mp3_to_tensor",
+                              return_value=(torch.randn(100), 32000)):
+                adapter.generate_single("test", enable_audio_cache=False)
+
+        assert captured_args["voice_id"] == "Deep_Voice_Man"
+        assert captured_args["model"] == "speech-2.8-turbo"
+        assert captured_args["speed"] == 1.5
+
+    def test_generate_single_kwargs_override(self):
+        """generate_single kwargs should override config."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({
+            "api_key": "k",
+            "voice_id": "cute_boy",
+            "model": "speech-2.8-hd",
+        })
+
+        captured_args = {}
+
+        def capture_call(text, voice_id, model, speed):
+            captured_args.update({"voice_id": voice_id, "model": model})
+            return b"\x00" * 100
+
+        with patch.object(adapter, "_call_tts_api", side_effect=capture_call):
+            with patch.object(adapter, "_decode_mp3_to_tensor",
+                              return_value=(torch.randn(100), 32000)):
+                adapter.generate_single(
+                    "test", enable_audio_cache=False,
+                    voice_id="Wise_Woman", model="speech-2.8-turbo"
+                )
+
+        assert captured_args["voice_id"] == "Wise_Woman"
+        assert captured_args["model"] == "speech-2.8-turbo"
+
+
+@pytest.mark.unit
+class TestMiniMaxTTSAdapterProcessText:
+    """Tests for process_text method."""
+
+    def test_process_text_returns_tensor(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "k"})
+
+        fake_chunk = torch.randn(16000)
+
+        with patch.object(adapter, "generate_single",
+                          return_value=(fake_chunk, 32000)):
+            result = adapter.process_text("Hello world", enable_chunking=False)
+
+        assert isinstance(result, torch.Tensor)
+        assert result.numel() > 0
+
+    def test_process_text_with_return_info(self):
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        adapter = MiniMaxTTSAdapter({"api_key": "k"})
+
+        with patch.object(adapter, "generate_single",
+                          return_value=(torch.randn(16000), 32000)):
+            result, info = adapter.process_text(
+                "Hello", enable_chunking=False, return_info=True
+            )
+
+        assert isinstance(result, torch.Tensor)
+        # info may be None for single-chunk text; verify the 2-tuple return shape
+        assert isinstance(info, (dict, list, type(None)))
+
+
+@pytest.mark.unit
+class TestMiniMaxVoiceConstants:
+    """Tests for voice and model constants."""
+
+    def test_voice_ids_list(self):
+        from engines.adapters.minimax_tts_adapter import MINIMAX_VOICE_IDS
+        assert len(MINIMAX_VOICE_IDS) == 12
+        assert "English_Graceful_Lady" in MINIMAX_VOICE_IDS
+        assert "Deep_Voice_Man" in MINIMAX_VOICE_IDS
+        assert "cute_boy" in MINIMAX_VOICE_IDS
+
+    def test_models_list(self):
+        from engines.adapters.minimax_tts_adapter import MINIMAX_MODELS
+        assert "speech-2.8-hd" in MINIMAX_MODELS
+        assert "speech-2.8-turbo" in MINIMAX_MODELS
+
+    def test_voice_descriptions(self):
+        from engines.adapters.minimax_tts_adapter import MINIMAX_VOICES
+        assert MINIMAX_VOICES["English_Graceful_Lady"] == "Graceful Lady (English)"
+        assert MINIMAX_VOICES["Deep_Voice_Man"] == "Deep Voice Man"
+
+
+@pytest.mark.unit
+class TestMiniMaxDecodeMp3:
+    """Tests for MP3 decoding static method."""
+
+    def test_decode_normalizes_multichannel(self):
+        """Multi-channel audio should be averaged to mono."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        stereo = torch.randn(2, 16000)
+
+        with patch("torchaudio.load", return_value=(stereo, 32000)):
+            audio, sr = MiniMaxTTSAdapter._decode_mp3_to_tensor(b"\x00")
+
+        assert audio.dim() == 1
+        assert sr == 32000
+
+    def test_decode_normalizes_amplitude(self):
+        """Audio with values > 1.0 should be normalized to [-1, 1]."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        loud = torch.tensor([[5.0, -3.0, 2.0]])
+
+        with patch("torchaudio.load", return_value=(loud, 32000)):
+            audio, sr = MiniMaxTTSAdapter._decode_mp3_to_tensor(b"\x00")
+
+        assert audio.abs().max() <= 1.0
+
+    def test_decode_keeps_quiet_audio(self):
+        """Audio already in [-1, 1] range should not be modified."""
+        from engines.adapters.minimax_tts_adapter import MiniMaxTTSAdapter
+
+        quiet = torch.tensor([[0.5, -0.3, 0.1]])
+
+        with patch("torchaudio.load", return_value=(quiet, 32000)):
+            audio, sr = MiniMaxTTSAdapter._decode_mp3_to_tensor(b"\x00")
+
+        assert torch.allclose(audio, quiet.squeeze(0))

--- a/utils/audio/cache.py
+++ b/utils/audio/cache.py
@@ -347,6 +347,27 @@ class Qwen3TTSCacheKeyGenerator(CacheKeyGenerator):
         return hashlib.md5(cache_string.encode()).hexdigest()
 
 
+class MiniMaxTTSCacheKeyGenerator(CacheKeyGenerator):
+    """Cache key generator for MiniMax Cloud TTS engine."""
+
+    def generate_cache_key(self, **params) -> str:
+        """Generate MiniMax TTS cache key from parameters."""
+        speed = params.get('speed', 1.0)
+        if isinstance(speed, (int, float)):
+            speed = round(float(speed), 3)
+
+        cache_data = {
+            'text': params.get('text', ''),
+            'voice_id': params.get('voice_id', 'English_Graceful_Lady'),
+            'model': params.get('model', 'speech-2.8-hd'),
+            'speed': speed,
+            'engine': 'minimax_tts'
+        }
+
+        cache_string = str(sorted(cache_data.items()))
+        return hashlib.md5(cache_string.encode()).hexdigest()
+
+
 class EchoTTSCacheKeyGenerator(CacheKeyGenerator):
     """Cache key generator for Echo-TTS engine."""
 
@@ -422,7 +443,8 @@ class AudioCache:
             'index_tts': IndexTTSCacheKeyGenerator(),
             'cosyvoice': CosyVoiceCacheKeyGenerator(),
             'qwen3_tts': Qwen3TTSCacheKeyGenerator(),
-            'echo_tts': EchoTTSCacheKeyGenerator()
+            'echo_tts': EchoTTSCacheKeyGenerator(),
+            'minimax_tts': MiniMaxTTSCacheKeyGenerator()
         }
     
     def register_cache_key_generator(self, engine_type: str, generator: CacheKeyGenerator):
@@ -497,6 +519,8 @@ class AudioCache:
             sample_rate = 24000
         elif engine_type in ('index_tts', 'cosyvoice'):
             sample_rate = 22050
+        elif engine_type == 'minimax_tts':
+            sample_rate = 32000
         else:
             sample_rate = 44100
         return num_samples / sample_rate


### PR DESCRIPTION
## Summary

Add **MiniMax Cloud TTS** as the 13th engine in TTS-Audio-Suite, bringing cloud-based text-to-speech with no GPU requirements.

### What's included

- **MiniMax TTS Adapter** (`engines/adapters/minimax_tts_adapter.py`) — Cloud API integration via MiniMax T2A v2 endpoint, with MP3 decoding, speed clamping, and error handling
- **Engine Node** (`nodes/engines/minimax_tts_engine_node.py`) — ComfyUI configuration node with model/voice/speed selection
- **Unified Node Integration** — Full routing in both `tts_text_node.py` and `tts_srt_node.py` including text chunking, SRT timing, and overlap handling
- **Cache Support** — `MiniMaxTTSCacheKeyGenerator` registered in the audio cache system with 32kHz sample rate
- **Node Registration** — Loaded in `nodes.py` with `NODE_CLASS_MAPPINGS` / `NODE_DISPLAY_NAME_MAPPINGS`
- **README & Docs** — Engine count updated (12 → 13), comparison table entry, full usage section with voice table

### Models & Voices

| Model | Description |
|-------|-------------|
| `speech-2.8-hd` | High definition, best quality |
| `speech-2.8-turbo` | Fast generation, lower latency |

12 built-in voices: English_Graceful_Lady, English_Insightful_Speaker, English_radiant_girl, English_Persuasive_Man, English_Lucky_Robot, Wise_Woman, cute_boy, lovely_girl, Friendly_Person, Inspirational_girl, Deep_Voice_Man, sweet_girl

### Test Coverage

- **25 unit tests** — Config, API key resolution, payload building, speed clamping, error responses, generation flow, caching, MP3 decode normalization
- **11 integration tests** — Engine node metadata/output format, end-to-end flow, text chunking, cache hit verification, node registration
- All 36 tests pass ✅

### Files Changed (11 files, ~1544 additions)

| File | Change |
|------|--------|
| `engines/adapters/minimax_tts_adapter.py` | New adapter (260 lines) |
| `nodes/engines/minimax_tts_engine_node.py` | New engine node |
| `engines/adapters/__init__.py` | Import + availability flag |
| `nodes.py` | Node loading + registration |
| `nodes/unified/tts_text_node.py` | MiniMax routing in generate_speech |
| `nodes/unified/tts_srt_node.py` | MiniMax routing in SRT generation |
| `utils/audio/cache.py` | Cache key generator + sample rate |
| `README.md` | Engine count, table, docs |
| `docs/Dev reports/tts_audio_suite_engines.yaml` | Engine spec |
| `tests/unit/test_minimax_tts_adapter.py` | 25 unit tests |
| `tests/integration/test_minimax_tts_integration.py` | 11 integration tests |

## Test plan

- [x] All 36 tests pass (`pytest tests/unit/test_minimax_tts_adapter.py tests/integration/test_minimax_tts_integration.py -v`)
- [ ] Verify MiniMax TTS node appears in ComfyUI node browser under Engines category
- [ ] Test TTS generation with valid `MINIMAX_API_KEY` env var
- [ ] Test SRT subtitle generation with MiniMax engine
