### PR TITLE
Fix Python 3.13 librosa initialization in ChatterBox engines

### DIFF
--- a/engines/chatterbox/models/s3gen/utils/mel.py
+++ b/engines/chatterbox/models/s3gen/utils/mel.py
@@ -1,4 +1,11 @@
 """mel-spectrogram extraction in Matcha-TTS"""
+# Smart numba compatibility for mel spectrogram extraction
+from utils.compatibility import setup_numba_compatibility
+setup_numba_compatibility(
+    quick_startup=True,
+    verbose=False,
+)
+
 from librosa.filters import mel as librosa_mel_fn
 import torch
 import numpy as np

--- a/engines/chatterbox_official_23lang/models/s3gen/utils/mel.py
+++ b/engines/chatterbox_official_23lang/models/s3gen/utils/mel.py
@@ -1,5 +1,13 @@
 """mel-spectrogram extraction in Matcha-TTS"""
 import logging
+
+# Smart numba compatibility for mel spectrogram extraction
+from utils.compatibility import setup_numba_compatibility
+setup_numba_compatibility(
+    quick_startup=True,
+    verbose=False,
+)
+
 from librosa.filters import mel as librosa_mel_fn
 import torch
 import numpy as np


### PR DESCRIPTION
## Summary

This PR updates **both ChatterBox implementations** to initialize the Python 3.13 compatibility layer before the first `librosa` import.

### Affected files

- `engines/chatterbox/models/s3gen/utils/mel.py`
- `engines/chatterbox_official_23lang/models/s3gen/utils/mel.py`

## Background

While testing TTS-Audio-Suite on:

- Windows 11
- Python 3.13.12
- ComfyUI Desktop
- NVIDIA RTX 4060 Laptop GPU
- CUDA 13

both ChatterBox engines failed during initialization with errors such as:

```text
Failed in nopython mode pipeline
Failed to create engine node instance
```

During investigation, both `mel.py` files were found to import:

```python
from librosa.filters import mel as librosa_mel_fn
```

before calling:

```python
setup_numba_compatibility()
```

## Change

Both `mel.py` files now initialize the compatibility layer before importing `librosa`:

```python
from utils.compatibility import setup_numba_compatibility

setup_numba_compatibility(
    quick_startup=True,
    verbose=False,
)

from librosa.filters import mel as librosa_mel_fn
```

## Validation

Test environment:

- Windows 11
- Python 3.13.12
- ComfyUI Desktop
- NVIDIA RTX 4060 Laptop GPU
- CUDA 13

Observed after applying this patch:

- Both ChatterBox engines initialize successfully.
- Required models download correctly.
- Audio generation completes successfully.
- The previous initialization error is no longer reproduced.

This change applies the same compatibility initialization consistently across both ChatterBox implementations.